### PR TITLE
Fixed floating logo error on mobile

### DIFF
--- a/_layout/sidebar.html
+++ b/_layout/sidebar.html
@@ -36,7 +36,7 @@
     </nav>
 
   </div>
-  <div style="font-size: 0.85em; bottom: 3em; position: fixed">
+  <div style="font-size: 0.85em; bottom: 3em; position: absolute">
       <a href="https://github.com/JuliaSymbolics/">Go to GitHub organization &rarr;</a> <br>  <br>
 
       <a href="https://julialang.org/"><img src="https://raw.githubusercontent.com/JuliaLang/julia-logo-graphics/master/images/julia-logo-dark.svg" height="32" style="display: inline-block; margin-bottom: -8px; opacity: 0.7">

--- a/_layout/sidebar.html
+++ b/_layout/sidebar.html
@@ -25,6 +25,12 @@
         color: #cccccc;
         margin: 0.25em 0;
     }
+      
+    .sidebar-logo {
+        font-size: 0.85em;
+        bottom: 3em;
+        position: inherit;
+    }
     </style>
     <nav class="sidebar-nav" style="opacity: 0.9">
       <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/">Overview</a>
@@ -36,7 +42,7 @@
     </nav>
 
   </div>
-  <div style="font-size: 0.85em; bottom: 3em; position: absolute">
+  <div class="sidebar-logo">
       <a href="https://github.com/JuliaSymbolics/">Go to GitHub organization &rarr;</a> <br>  <br>
 
       <a href="https://julialang.org/"><img src="https://raw.githubusercontent.com/JuliaLang/julia-logo-graphics/master/images/julia-logo-dark.svg" height="32" style="display: inline-block; margin-bottom: -8px; opacity: 0.7">


### PR DESCRIPTION
The "Go to GitHub organization, Julia powered" block of the sidebar was still rendered behind the page content when the sidebar was hidden (eg, on mobile). It looked like just a few dots were randomly hovering because the text and most of the logo image where white rendered on white. Changing the position from "fixed" to ~~"absolute"~~ "inherit" hides this block when the sidebar is hidden.